### PR TITLE
Fix monitor_directory TOCTOU and symlink loop vulnerabilities

### DIFF
--- a/rope/GUI.py
+++ b/rope/GUI.py
@@ -3,6 +3,7 @@ import shutil
 import traceback
 import cv2
 import tkinter as tk
+import logging
 from tkinter import filedialog, font
 import numpy as np
 from PIL import Image, ImageTk, ImageSequence, PngImagePlugin
@@ -3114,34 +3115,56 @@ class GUI(tk.Tk):
         user_loaded_new_directory = True
         self.monitor_directory(user_loaded_new_directory)
 
+    def _scan_directory_safely(self, directory):
+        """
+        Safely scan directory for files, handling symlink loops and access errors.
+        
+        Args:
+            directory: Path to the directory to scan
+            
+        Returns:
+            List of file paths found in the directory and subdirectories
+        """
+        visited_dirs = set()
+        filenames = []
+        
+        def onerror(error):
+            """Handle errors during directory walk."""
+            logging.debug(f"Error accessing directory during walk: {error}")
+        
+        for dirpath, dirnames, files in os.walk(directory, followlinks=True, onerror=onerror):
+            # Get real path to detect symlink loops
+            try:
+                real_dirpath = os.path.realpath(dirpath)
+                if real_dirpath in visited_dirs:
+                    dirnames[:] = []  # Don't recurse into this directory
+                    continue
+                visited_dirs.add(real_dirpath)
+            except OSError as e:
+                # Skip directories we can't access
+                logging.debug(f"Cannot access directory {dirpath}: {e}")
+                dirnames[:] = []
+                continue
+            
+            # Collect all files from this directory
+            for f in files:
+                filenames.append(os.path.join(dirpath, f))
+                
+        return filenames
+
     def monitor_directory(self, user_loaded_new_directory = False):
 
         # Recursively read all media files from directory
         directory =  self.json_dict["source videos"]
+        logging.debug(f"Monitoring directory: {directory}")
         
-        # Track visited directories to prevent symlink loops
-        visited_dirs = set()
-        filenames = []
-        
+        # Use helper method to safely scan directory
         try:
-            for dirpath, dirnames, files in os.walk(directory, followlinks=True):
-                # Get real path to detect symlink loops
-                try:
-                    real_dirpath = os.path.realpath(dirpath)
-                    if real_dirpath in visited_dirs:
-                        dirnames[:] = []  # Don't recurse into this directory
-                        continue
-                    visited_dirs.add(real_dirpath)
-                except OSError:
-                    # Skip directories we can't access
-                    dirnames[:] = []
-                    continue
-                
-                # Collect all files from this directory
-                for f in files:
-                    filenames.append(os.path.join(dirpath, f))
-        except OSError:
+            filenames = self._scan_directory_safely(directory)
+            logging.debug(f"Found {len(filenames)} files in directory")
+        except OSError as e:
             # If the base directory doesn't exist or is inaccessible, use empty list
+            logging.debug(f"Cannot access base directory {directory}: {e}")
             filenames = []
 
         # Convert both lists to sets
@@ -3156,32 +3179,31 @@ class GUI(tk.Tk):
 
         # Remove files that were removed externally
         if removed_files:
+            logging.debug(f"Found {len(removed_files)} removed files")
             self.target_media_shuffle_history = set()
             
             for removed_file in removed_files:
+                logging.debug(f"Removing file from list: {removed_file}")
                 self.remove_target_media_from_list(removed_file)
                 self.last_filenames.remove(removed_file)
 
         # Add new files and select the newest file
         if new_files:
+            logging.debug(f"Found {len(new_files)} new files")
 
             # Sort new_files, newest creation time last - handle TOCTOU race condition
-            def safe_getctime(path):
-                try:
-                    return os.path.getctime(path)
-                except OSError:
-                    return None  # Return None for missing files
-            
-            # Annotate files with their creation times to sort efficiently and safely.
-            # This is the Decorate-Sort-Undecorate pattern.
+            # Build annotated files list with creation times, filtering out inaccessible files
             annotated_files = []
             for f in new_files:
-                ctime = safe_getctime(f)
-                if ctime is not None:
+                try:
+                    ctime = os.path.getctime(f)
                     annotated_files.append((ctime, f))
+                except OSError:
+                    # Skip files we can't access
+                    logging.debug(f"Cannot get creation time for file {f}")
             
-            annotated_files.sort()  # Sorts by ctime, then by filename as a tie-breaker
-            new_files = [f for ctime, f in annotated_files]
+            # Sort by creation time and extract file paths in one step
+            new_files = [f for ctime, f in sorted(annotated_files)]
         
             for new_file in new_files:
                 # Create and extend buttons into button list

--- a/rope/GUI.py
+++ b/rope/GUI.py
@@ -3162,14 +3162,19 @@ class GUI(tk.Tk):
         directory =  self.json_dict["source videos"]
         logger.debug(f"Monitoring directory: {directory}")
         
-        # Use helper method to safely scan directory
-        try:
-            filenames = self._scan_directory_safely(directory)
-            logger.debug(f"Found {len(filenames)} files in directory")
-        except (OSError, TypeError) as e:
-            # If the base directory doesn't exist or is inaccessible, use empty list
-            logger.warning(f"Cannot access base directory {directory}: {e}")
+        # Validate directory before scanning
+        if not directory or not isinstance(directory, str) or not directory.strip():
+            logger.debug("No valid directory specified for monitoring")
             filenames = []
+        else:
+            # Use helper method to safely scan directory
+            try:
+                filenames = self._scan_directory_safely(directory)
+                logger.debug(f"Found {len(filenames)} files in directory")
+            except (OSError, TypeError) as e:
+                # If the base directory doesn't exist or is inaccessible, use empty list
+                logger.warning(f"Cannot access base directory {directory}: {e}")
+                filenames = []
 
         # Convert both lists to sets
         set_filenames = set(filenames)

--- a/rope/GUI.py
+++ b/rope/GUI.py
@@ -3172,9 +3172,16 @@ class GUI(tk.Tk):
                 except OSError:
                     return None  # Return None for missing files
             
-            # Filter out files that no longer exist
-            valid_files = [f for f in new_files if safe_getctime(f) is not None]
-            new_files = sorted(valid_files, key=safe_getctime)
+            # Annotate files with their creation times to sort efficiently and safely.
+            # This is the Decorate-Sort-Undecorate pattern.
+            annotated_files = []
+            for f in new_files:
+                ctime = safe_getctime(f)
+                if ctime is not None:
+                    annotated_files.append((ctime, f))
+            
+            annotated_files.sort()  # Sorts by ctime, then by filename as a tie-breaker
+            new_files = [f for ctime, f in annotated_files]
         
             for new_file in new_files:
                 # Create and extend buttons into button list

--- a/rope/GUI.py
+++ b/rope/GUI.py
@@ -3133,7 +3133,7 @@ class GUI(tk.Tk):
         """
         visited_dirs = set()
         filenames = []
-        base_depth = directory.count(os.path.sep)
+        base_depth = os.path.normpath(directory).count(os.path.sep)
         
         def onerror(error):
             """Handle errors during directory walk."""

--- a/rope/GUI.py
+++ b/rope/GUI.py
@@ -3133,7 +3133,7 @@ class GUI(tk.Tk):
         """
         visited_dirs = set()
         filenames = []
-        base_depth = os.path.normpath(directory).count(os.path.sep)
+        base_depth = directory.count(os.path.sep)
         
         def onerror(error):
             """Handle errors during directory walk."""

--- a/rope/GUI.py
+++ b/rope/GUI.py
@@ -42,6 +42,9 @@ import gc
 # Module-level logger
 logger = logging.getLogger(__name__)
 
+# Constants
+MAX_SCAN_DEPTH = 20  # Maximum directory recursion depth to prevent stack overflow
+
 def process_video(file):
 
     def resize_video(video_frame):
@@ -3130,7 +3133,6 @@ class GUI(tk.Tk):
         """
         visited_dirs = set()
         filenames = []
-        max_depth = 20  # Prevent excessive recursion
         
         def onerror(error):
             """Handle errors during directory walk."""
@@ -3138,11 +3140,15 @@ class GUI(tk.Tk):
         
         for dirpath, dirnames, files in os.walk(directory, followlinks=True, onerror=onerror):
             # Check recursion depth
-            depth = dirpath[len(directory):].count(os.sep)
-            if depth > max_depth:
-                logger.info(f"Skipping deeply nested directory (>{max_depth} levels): {dirpath}")
-                dirnames[:] = []
-                continue
+            try:
+                depth = len(os.path.relpath(dirpath, directory).split(os.sep)) - 1
+                if depth > MAX_SCAN_DEPTH:
+                    logger.info(f"Skipping deeply nested directory (>{MAX_SCAN_DEPTH} levels): {dirpath}")
+                    dirnames[:] = []
+                    continue
+            except ValueError:
+                # Can happen if dirpath and directory are on different drives on Windows
+                pass
             # Get real path to detect symlink loops
             try:
                 real_dirpath = os.path.realpath(dirpath)

--- a/rope/GUI.py
+++ b/rope/GUI.py
@@ -3118,7 +3118,31 @@ class GUI(tk.Tk):
 
         # Recursively read all media files from directory
         directory =  self.json_dict["source videos"]
-        filenames = [os.path.join(dirpath,f) for (dirpath, dirnames, filenames) in os.walk(directory, followlinks=True) for f in filenames]
+        
+        # Track visited directories to prevent symlink loops
+        visited_dirs = set()
+        filenames = []
+        
+        try:
+            for dirpath, dirnames, files in os.walk(directory, followlinks=True):
+                # Get real path to detect symlink loops
+                try:
+                    real_dirpath = os.path.realpath(dirpath)
+                    if real_dirpath in visited_dirs:
+                        dirnames[:] = []  # Don't recurse into this directory
+                        continue
+                    visited_dirs.add(real_dirpath)
+                except (OSError, IOError):
+                    # Skip directories we can't access
+                    dirnames[:] = []
+                    continue
+                
+                # Collect all files from this directory
+                for f in files:
+                    filenames.append(os.path.join(dirpath, f))
+        except (OSError, IOError):
+            # If the base directory doesn't exist or is inaccessible, use empty list
+            filenames = []
 
         # Convert both lists to sets
         set_filenames = set(filenames)
@@ -3141,8 +3165,14 @@ class GUI(tk.Tk):
         # Add new files and select the newest file
         if new_files:
 
-            # Sort new_files, newest creation time last
-            new_files = sorted(new_files, key=lambda x: os.path.getctime(x))
+            # Sort new_files, newest creation time last - handle TOCTOU race condition
+            def safe_getctime(path):
+                try:
+                    return os.path.getctime(path)
+                except (OSError, IOError):
+                    return 0  # Return epoch time for missing files
+            
+            new_files = sorted(new_files, key=safe_getctime)
         
             for new_file in new_files:
                 # Create and extend buttons into button list

--- a/rope/GUI.py
+++ b/rope/GUI.py
@@ -3155,7 +3155,7 @@ class GUI(tk.Tk):
                 continue
             
             # Then check depth to prevent excessive recursion
-            current_depth = dirpath.count(os.path.sep)
+            current_depth = os.path.normpath(dirpath).count(os.path.sep)
             depth = current_depth - base_depth
             if depth > MAX_SCAN_DEPTH:
                 logger.info(f"Skipping deeply nested directory (depth={depth}): {dirpath}")
@@ -3234,7 +3234,7 @@ class GUI(tk.Tk):
                 try:
                     ctime = os.path.getctime(filepath)
                     file_times.append((ctime, filepath))
-                except OSError as e:
+                except (FileNotFoundError, PermissionError) as e:
                     # File disappeared or became inaccessible - this is expected in TOCTOU scenarios
                     logger.debug(f"Skipping inaccessible file {filepath}: {e}")
             
@@ -3249,7 +3249,7 @@ class GUI(tk.Tk):
                     if len(new_media_buttons) > 0:
                         self.target_media_buttons.extend(new_media_buttons)
                         self.last_filenames.append(new_file)
-                except Exception as e:
+                except OSError as e:
                     # File might have disappeared or become inaccessible (TOCTOU)
                     logger.info(f"Could not process file {new_file}: {e}")
 

--- a/rope/GUI.py
+++ b/rope/GUI.py
@@ -39,6 +39,9 @@ from rope.FaceEditor import FaceEditor
 from rope.Hovertip import RopeHovertip
 import gc
 
+# Module-level logger
+logger = logging.getLogger(__name__)
+
 def process_video(file):
 
     def resize_video(video_frame):
@@ -3130,7 +3133,7 @@ class GUI(tk.Tk):
         
         def onerror(error):
             """Handle errors during directory walk."""
-            logging.debug(f"Error accessing directory during walk: {error}")
+            logger.debug(f"Error accessing directory during walk: {error}")
         
         for dirpath, dirnames, files in os.walk(directory, followlinks=True, onerror=onerror):
             # Get real path to detect symlink loops
@@ -3142,7 +3145,7 @@ class GUI(tk.Tk):
                 visited_dirs.add(real_dirpath)
             except OSError as e:
                 # Skip directories we can't access
-                logging.debug(f"Cannot access directory {dirpath}: {e}")
+                logger.debug(f"Cannot access directory {dirpath}: {e}")
                 dirnames[:] = []
                 continue
             
@@ -3156,15 +3159,15 @@ class GUI(tk.Tk):
 
         # Recursively read all media files from directory
         directory =  self.json_dict["source videos"]
-        logging.debug(f"Monitoring directory: {directory}")
+        logger.debug(f"Monitoring directory: {directory}")
         
         # Use helper method to safely scan directory
         try:
             filenames = self._scan_directory_safely(directory)
-            logging.debug(f"Found {len(filenames)} files in directory")
-        except OSError as e:
+            logger.debug(f"Found {len(filenames)} files in directory")
+        except (OSError, TypeError) as e:
             # If the base directory doesn't exist or is inaccessible, use empty list
-            logging.debug(f"Cannot access base directory {directory}: {e}")
+            logger.warning(f"Cannot access base directory {directory}: {e}")
             filenames = []
 
         # Convert both lists to sets
@@ -3179,17 +3182,17 @@ class GUI(tk.Tk):
 
         # Remove files that were removed externally
         if removed_files:
-            logging.debug(f"Found {len(removed_files)} removed files")
+            logger.debug(f"Found {len(removed_files)} removed files")
             self.target_media_shuffle_history = set()
             
             for removed_file in removed_files:
-                logging.debug(f"Removing file from list: {removed_file}")
+                logger.debug(f"Removing file from list: {removed_file}")
                 self.remove_target_media_from_list(removed_file)
                 self.last_filenames.remove(removed_file)
 
         # Add new files and select the newest file
         if new_files:
-            logging.debug(f"Found {len(new_files)} new files")
+            logger.debug(f"Found {len(new_files)} new files")
 
             # Sort new_files, newest creation time last - handle TOCTOU race condition
             # Build annotated files list with creation times, filtering out inaccessible files
@@ -3200,7 +3203,7 @@ class GUI(tk.Tk):
                     annotated_files.append((ctime, f))
                 except OSError:
                     # Skip files we can't access
-                    logging.debug(f"Cannot get creation time for file {f}")
+                    logger.debug(f"Cannot get creation time for file {f}")
             
             # Sort by creation time and extract file paths in one step
             new_files = [f for ctime, f in sorted(annotated_files)]

--- a/rope/GUI.py
+++ b/rope/GUI.py
@@ -3130,12 +3130,19 @@ class GUI(tk.Tk):
         """
         visited_dirs = set()
         filenames = []
+        max_depth = 20  # Prevent excessive recursion
         
         def onerror(error):
             """Handle errors during directory walk."""
             logger.debug(f"Error accessing directory during walk: {error}")
         
         for dirpath, dirnames, files in os.walk(directory, followlinks=True, onerror=onerror):
+            # Check recursion depth
+            depth = dirpath[len(directory):].count(os.sep)
+            if depth > max_depth:
+                logger.info(f"Skipping deeply nested directory (>{max_depth} levels): {dirpath}")
+                dirnames[:] = []
+                continue
             # Get real path to detect symlink loops
             try:
                 real_dirpath = os.path.realpath(dirpath)
@@ -3216,11 +3223,13 @@ class GUI(tk.Tk):
         
             for new_file in new_files:
                 # Create and extend buttons into button list
-                new_media_buttons = self.add_target_media_buttons([new_file])
-
-                if len(new_media_buttons) > 0:
-                    self.target_media_buttons.extend(new_media_buttons)
-                    self.last_filenames.append(new_file)
+                try:
+                    new_media_buttons = self.add_target_media_buttons([new_file])
+                    if len(new_media_buttons) > 0:
+                        self.target_media_buttons.extend(new_media_buttons)
+                        self.last_filenames.append(new_file)
+                except (OSError, IOError) as e:
+                    logger.info(f"File disappeared before processing: {new_file} - {e}")
 
             self.all_target_media_thumbnails_generated = False
 

--- a/rope/GUI.py
+++ b/rope/GUI.py
@@ -3132,7 +3132,7 @@ class GUI(tk.Tk):
                         dirnames[:] = []  # Don't recurse into this directory
                         continue
                     visited_dirs.add(real_dirpath)
-                except (OSError, IOError):
+                except OSError:
                     # Skip directories we can't access
                     dirnames[:] = []
                     continue
@@ -3140,7 +3140,7 @@ class GUI(tk.Tk):
                 # Collect all files from this directory
                 for f in files:
                     filenames.append(os.path.join(dirpath, f))
-        except (OSError, IOError):
+        except OSError:
             # If the base directory doesn't exist or is inaccessible, use empty list
             filenames = []
 
@@ -3169,10 +3169,12 @@ class GUI(tk.Tk):
             def safe_getctime(path):
                 try:
                     return os.path.getctime(path)
-                except (OSError, IOError):
-                    return 0  # Return epoch time for missing files
+                except OSError:
+                    return None  # Return None for missing files
             
-            new_files = sorted(new_files, key=safe_getctime)
+            # Filter out files that no longer exist
+            valid_files = [f for f in new_files if safe_getctime(f) is not None]
+            new_files = sorted(valid_files, key=safe_getctime)
         
             for new_file in new_files:
                 # Create and extend buttons into button list

--- a/rope/GUI.py
+++ b/rope/GUI.py
@@ -3139,15 +3139,16 @@ class GUI(tk.Tk):
             # Get real path to detect symlink loops
             try:
                 real_dirpath = os.path.realpath(dirpath)
-                if real_dirpath in visited_dirs:
-                    dirnames[:] = []  # Don't recurse into this directory
-                    continue
-                visited_dirs.add(real_dirpath)
             except OSError as e:
                 # Skip directories we can't access
                 logger.debug(f"Cannot access directory {dirpath}: {e}")
                 dirnames[:] = []
                 continue
+
+            if real_dirpath in visited_dirs:
+                dirnames[:] = []  # Don't recurse into this directory
+                continue
+            visited_dirs.add(real_dirpath)
             
             # Collect all files from this directory
             for f in files:

--- a/rope/GUI.py
+++ b/rope/GUI.py
@@ -3126,68 +3126,82 @@ class GUI(tk.Tk):
         Safely scan directory for files, handling symlink loops and access errors.
         
         Args:
-            directory: Path to the directory to scan
+            directory: Path to the directory to scan (must be normalized)
             
         Returns:
             List of file paths found in the directory and subdirectories
         """
         visited_dirs = set()
         filenames = []
+        base_depth = directory.count(os.path.sep)
         
         def onerror(error):
             """Handle errors during directory walk."""
-            logger.debug(f"Error accessing directory during walk: {error}")
+            logger.debug(f"Error accessing path during walk: {error}")
         
         for dirpath, dirnames, files in os.walk(directory, followlinks=True, onerror=onerror):
-            # Check recursion depth
-            try:
-                depth = len(os.path.relpath(dirpath, directory).split(os.sep)) - 1
-                if depth > MAX_SCAN_DEPTH:
-                    logger.info(f"Skipping deeply nested directory (>{MAX_SCAN_DEPTH} levels): {dirpath}")
-                    dirnames[:] = []
-                    continue
-            except ValueError:
-                # Can happen if dirpath and directory are on different drives on Windows
-                pass
-            # Get real path to detect symlink loops
+            # First, check symlink loops using real path
             try:
                 real_dirpath = os.path.realpath(dirpath)
+                if real_dirpath in visited_dirs:
+                    logger.debug(f"Skipping symlink loop: {dirpath} -> {real_dirpath}")
+                    dirnames[:] = []  # Don't recurse into this directory
+                    continue
+                visited_dirs.add(real_dirpath)
             except OSError as e:
-                # Skip directories we can't access
-                logger.debug(f"Cannot access directory {dirpath}: {e}")
+                # Can't resolve real path, skip this directory
+                logger.debug(f"Cannot resolve real path for {dirpath}: {e}")
                 dirnames[:] = []
                 continue
-
-            if real_dirpath in visited_dirs:
-                dirnames[:] = []  # Don't recurse into this directory
+            
+            # Then check depth to prevent excessive recursion
+            current_depth = dirpath.count(os.path.sep)
+            depth = current_depth - base_depth
+            if depth > MAX_SCAN_DEPTH:
+                logger.info(f"Skipping deeply nested directory (depth={depth}): {dirpath}")
+                dirnames[:] = []
                 continue
-            visited_dirs.add(real_dirpath)
             
             # Collect all files from this directory
             for f in files:
-                filenames.append(os.path.join(dirpath, f))
+                filepath = os.path.join(dirpath, f)
+                filenames.append(filepath)
                 
         return filenames
 
     def monitor_directory(self, user_loaded_new_directory = False):
-
-        # Recursively read all media files from directory
-        directory =  self.json_dict["source videos"]
-        logger.debug(f"Monitoring directory: {directory}")
+        """
+        Monitor directory for changes and update UI accordingly.
+        Thread-safety note: This method modifies shared state and should not be called concurrently.
+        """
+        # Get directory from config
+        directory = self.json_dict["source videos"]
+        logger.debug(f"Monitor directory called with: {directory}")
         
-        # Validate directory before scanning
+        # Validate and normalize directory
         if not directory or not isinstance(directory, str) or not directory.strip():
             logger.debug("No valid directory specified for monitoring")
             filenames = []
         else:
-            # Use helper method to safely scan directory
-            try:
-                filenames = self._scan_directory_safely(directory)
-                logger.debug(f"Found {len(filenames)} files in directory")
-            except (OSError, TypeError) as e:
-                # If the base directory doesn't exist or is inaccessible, use empty list
-                logger.warning(f"Cannot access base directory {directory}: {e}")
+            # Normalize path: strip whitespace, resolve . and .., remove trailing slashes
+            directory = os.path.normpath(directory.strip())
+            
+            # Check if path exists and is a directory
+            if not os.path.exists(directory):
+                logger.info(f"Directory does not exist: {directory}")
                 filenames = []
+            elif not os.path.isdir(directory):
+                logger.warning(f"Path exists but is not a directory: {directory}")
+                filenames = []
+            else:
+                # Directory is valid, scan it
+                try:
+                    filenames = self._scan_directory_safely(directory)
+                    logger.debug(f"Found {len(filenames)} files in directory")
+                except Exception as e:
+                    # Catch any unexpected errors
+                    logger.error(f"Unexpected error scanning directory {directory}: {e}", exc_info=True)
+                    filenames = []
 
         # Convert both lists to sets
         set_filenames = set(filenames)
@@ -3213,19 +3227,20 @@ class GUI(tk.Tk):
         if new_files:
             logger.debug(f"Found {len(new_files)} new files")
 
-            # Sort new_files, newest creation time last - handle TOCTOU race condition
-            # Build annotated files list with creation times, filtering out inaccessible files
-            annotated_files = []
-            for f in new_files:
+            # Sort new_files by creation time (newest last), handling TOCTOU race conditions
+            # Step 1: Get creation times for all files, filtering out inaccessible ones
+            file_times = []
+            for filepath in new_files:
                 try:
-                    ctime = os.path.getctime(f)
-                    annotated_files.append((ctime, f))
-                except OSError:
-                    # Skip files we can't access
-                    logger.debug(f"Cannot get creation time for file {f}")
+                    ctime = os.path.getctime(filepath)
+                    file_times.append((ctime, filepath))
+                except OSError as e:
+                    # File disappeared or became inaccessible - this is expected in TOCTOU scenarios
+                    logger.debug(f"Skipping inaccessible file {filepath}: {e}")
             
-            # Sort by creation time and extract file paths in one step
-            new_files = [f for ctime, f in sorted(annotated_files)]
+            # Step 2: Sort by creation time and extract just the file paths
+            file_times.sort(key=lambda x: x[0])  # Sort by ctime
+            new_files = [filepath for ctime, filepath in file_times]
         
             for new_file in new_files:
                 # Create and extend buttons into button list
@@ -3234,8 +3249,9 @@ class GUI(tk.Tk):
                     if len(new_media_buttons) > 0:
                         self.target_media_buttons.extend(new_media_buttons)
                         self.last_filenames.append(new_file)
-                except (OSError, IOError) as e:
-                    logger.info(f"File disappeared before processing: {new_file} - {e}")
+                except Exception as e:
+                    # File might have disappeared or become inaccessible (TOCTOU)
+                    logger.info(f"Could not process file {new_file}: {e}")
 
             self.all_target_media_thumbnails_generated = False
 


### PR DESCRIPTION
- Add symlink loop detection using visited_dirs set
- Track real paths to detect circular references
- Add safe_getctime() to handle files disappearing during sort
- Wrap os.walk in try/except for inaccessible directories
- Maintains full functionality with followlinks=True